### PR TITLE
fix json error in package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,11 +6,11 @@
   "license": "{{ license }}",
   "private": true,
   "scripts": {
-    "dev": "parcel -p 8080 index.html",
-    "build": "parcel build index.html --public-url /",
     {{#if runner}}
-    "test": "jest"
+    "test": "jest",
     {{/if}}
+    "dev": "parcel -p 8080 index.html",
+    "build": "parcel build index.html --public-url /"
   },
   "dependencies": {
     "vue": "^2.5.11"


### PR DESCRIPTION
```
{
  "name": "test",
  "description": "A Vue.js project",
  "version": "1.0.0",
  "author": "me",
  "license": "ISC",
  "private": true,
  "scripts": {
    "dev": "parcel -p 8080 index.html",
    "build": "parcel build index.html --public-url /",
  },
  "dependencies": {
    "vue": "^2.5.11"
  },
  "devDependencies": {
    "babel-core": "^6.26.0",
    "babel-preset-env": "^1.6.0",
    "cross-env": "^5.0.5",
    "node-sass": "^4.7.2",
    "parcel-bundler": "^1.3.1",
    "parcel-plugin-vue": "^1.4.0"
  }
}

```
this package.json is not legal because of `,` at the end of `"build": "parcel build index.html --public-url /",`